### PR TITLE
feat: Manage flight opening/closing, flight cancellations, and consistency of dates with stopovers

### DIFF
--- a/src/app/api/flights/[id]/cancel/route.ts
+++ b/src/app/api/flights/[id]/cancel/route.ts
@@ -1,0 +1,27 @@
+// src/app/api/flights/[id]/cancel/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/pirsma";
+import { handleError } from "@/utils/errorHandler";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const id = (await params).id;
+    const flight = await prisma.flight.update({
+      where: { id },
+      data: { flightStatus: "CANCELLED", bookingOpenStatus: false },
+    });
+
+    // Annuler éventuellement les réservations associées
+    await prisma.booking.updateMany({
+      where: { flightId: flight.id },
+      data: { bookingStatus: "CANCELLED" },
+    });
+
+    return NextResponse.json({ message: "Flight cancelled", flight });
+  } catch (error: any) {
+    return handleError(error, "Failed to cancel flight");
+  }
+}

--- a/src/app/api/flights/[id]/close/route.ts
+++ b/src/app/api/flights/[id]/close/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/pirsma";
+import { handleError } from "@/utils/errorHandler";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const id = (await params).id;
+    const flight = await prisma.flight.update({
+      where: { id },
+      data: { bookingOpenStatus: false },
+    });
+    return NextResponse.json({ message: "Flight booking closed", flight });
+  } catch (error: any) {
+    return handleError(error, "Failed to close flight booking");
+  }
+}

--- a/src/app/api/flights/[id]/open/route.ts
+++ b/src/app/api/flights/[id]/open/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/pirsma";
+import { handleError } from "@/utils/errorHandler";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const id = (await params).id;
+    const flight = await prisma.flight.update({
+      where: { id },
+      data: { bookingOpenStatus: true },
+    });
+    return NextResponse.json({ message: "Flight booking opened", flight });
+  } catch (error: any) {
+    return handleError(error, "Failed to open flight booking");
+  }
+}


### PR DESCRIPTION
Features: 
Opening/Closing flights
- admin can open/close a flight. 
added two endpoints:
- `POST /api/flights/:id/open` : met `bookingOpenStatus = true`
- `POST /api/flights/:id/close` : met bookingOpenStatus = false

Flight cancellation
- `POST /api/flights/:id/cancel : flightStatus = CANCELLED` and `bookingOpenStatus = false`.
- When canceling, you could also cancel the associated reservations. This is a logic choice.

Checking stopover consistency
When creating a stopover (`POST /api/flights/:id/stopovers`), check that the dates are consistent. Assume that the stopover is between the flight's `departureDate` and `arrivalDate`, and that it does not overlap with another stopover.